### PR TITLE
Add purescript 14.3 support using spago

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 firebase-debug.log
 /build/
 /examples/build/
+/.spago/

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,4 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
+
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,14 @@
+{ name = "apexcharts"
+, dependencies =
+  [ "aff"
+  , "contravariant"
+  , "effect"
+  , "foreign"
+  , "options"
+  , "prelude"
+  , "psci-support"
+  , "spec"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -57,16 +57,17 @@ import Apexcharts.Xaxis as X
 import Data.Options (Options, (:=))
 import Data.Options as Opt
 import Effect (Effect)
-import Effect.Aff (Aff)
+import Effect.Aff (Aff, launchAff_)
 import Foreign (Foreign)
 import Prelude (Unit, discard, ($), (<>))
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter (specReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
+
 
 main :: Effect Unit
-main = run [specReporter] do
+main = launchAff_ $ runSpec [specReporter] do
   describe "basic chart" do
     let 
       expected = "{\"chart\":{\"type\":\"line\"}," 


### PR DESCRIPTION
Resolves #7.
Note that although Spago is compiling fine, bower/pulp isn't afaik.