### PR TITLE
Allow creating an Apexchart directly from an Element

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -8,6 +8,7 @@
   , "prelude"
   , "psci-support"
   , "spec"
+  , "web-dom"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Apexcharts.js
+++ b/src/Apexcharts.js
@@ -9,10 +9,21 @@ exports._createChart = function(selector){
     }
 };
 
+exports._createChartEl = function(el){
+    return function(apexoptions){
+        return {el, apexoptions};
+    }
+};
+
 
 exports.render = function(chartDef){
     return function() {
-        var chart = new ApexCharts(document.querySelector(chartDef.selector), chartDef.apexoptions);
+        var chart;
+        if (chartDef.el) {
+            chart = new ApexCharts(chartDef.el, chartDef.apexoptions);
+        } else {
+            chart = new ApexCharts(document.querySelector(chartDef.selector), chartDef.apexoptions);
+        }
         chart.render();
     };
 };

--- a/src/Apexcharts.purs
+++ b/src/Apexcharts.purs
@@ -6,6 +6,7 @@ import Data.Options (Option, Options, opt)
 import Data.Options as Opt
 import Effect (Effect)
 import Foreign (Foreign)
+import Web.DOM.Element (Element)
 
 data Apexoptions
 
@@ -23,7 +24,12 @@ labels = opt "labels"
 createChart :: String -> Options Apexoptions -> Apexchart
 createChart selector opts = _createChart selector (Opt.options opts)
 
+createChartEl :: Element -> Options Apexoptions -> Apexchart
+createChartEl el opts = _createChartEl el (Opt.options opts)
+
 foreign import _createChart :: String -> Foreign -> Apexchart
+
+foreign import _createChartEl :: Element -> Foreign -> Apexchart
 
 foreign import render :: Apexchart -> Effect Unit
 


### PR DESCRIPTION
Nice to meet you!

This PR adds `Apexcharts.createChartEl`, a variant of `Apexcharts.createChart`, which takes an `Element` directly instead of a CSS selector. This makes integrating with Halogen much easier by allowing `LabelRef`, which can be dereferenced to an `Element` without assigning an `id` attribute to it.

The downside is that a new dependency to `web-dom` is required. Please let me know if you have a better way to resolve this.